### PR TITLE
merging anna's most recent feature into dev

### DIFF
--- a/src/data.sql
+++ b/src/data.sql
@@ -60,7 +60,7 @@ RETURNS TRIGGER AS $$
 BEGIN
     UPDATE events SET total_attendees = total_attendees + 1 WHERE event_id = OLD.event_id;
     RAISE NOTICE 'New attendee added to event %', OLD.event_id;
-    RETURN NEW;
+    RETURN NEW;  -- how are NEW and OLD defined here ? ---> possible cause of issue ?
 END
 $$ LANGUAGE plpgsql;
 

--- a/src/server/controllers/userController.ts
+++ b/src/server/controllers/userController.ts
@@ -167,14 +167,14 @@ const userController = {
             LEFT JOIN attendees 
             ON events.event_id = attendees.event_id
             WHERE user_id = $1
-            AND event_status = true
+            AND date_time >= now()
             ORDER BY date_time ASC;`;
 
             const attendedSQL = `SELECT * FROM events 
             LEFT JOIN attendees 
             ON events.event_id = attendees.event_id
             WHERE user_id = $1
-            AND event_status = false
+            AND date_time < now()
             ORDER BY date_time ASC;`;
 
             const hostRes: any = await query(hostSQL, [ req.user.user_id ]);

--- a/src/server/models/appModel.js
+++ b/src/server/models/appModel.js
@@ -1,15 +1,12 @@
 // pg model for blessing 
 import pg from 'pg';
 
-<<<<<<< HEAD
-// const PG_URI = "postgres://wbpifxvw:q8lghllZohqY4rkyYdpyF64er5iguO96@heffalump.db.elephantsql.com/wbpifxvw"
-const PG_URI = "postgres://lxigtjgl:wP50ncLWiiuuLCbVnZdsgx2XaV5ar3tr@lallah.db.elephantsql.com/lxigtjgl"
-=======
 // const PG_URI = "postgres://wbpifxvw:q8lghllZohqY4rkyYdpyF64er5iguO96@heffalump.db.elephantsql.com/wbpifxvw";
 // const PG_URI = "postgres://dvbusoaz:wrzUMGq27Wjwcs14lIS2CNZGpDwPlXSp@tiny.db.elephantsql.com/dvbusoaz";
-const PG_URI = "postgres://lxigtjgl:wP50ncLWiiuuLCbVnZdsgx2XaV5ar3tr@lallah.db.elephantsql.com/lxigtjgl";
+// const PG_URI = "postgres://lxigtjgl:wP50ncLWiiuuLCbVnZdsgx2XaV5ar3tr@lallah.db.elephantsql.com/lxigtjgl";
 
->>>>>>> fa1e01cb186bd130166694c48188e4f01b926209
+// kareem's most updated elephantSQL URI 
+const PG_URI = "postgres://eftajamv:JgPtjGfU29NkEq4Fm_4DHEmzpkNXhVnb@chunee.db.elephantsql.com/eftajamv";
 
 const pool = new pg.Pool({
   connectionString: PG_URI

--- a/src/server/routes/userRoutes.ts
+++ b/src/server/routes/userRoutes.ts
@@ -61,7 +61,7 @@ userRoutes.delete('/logout', (req: Request, res: Response, next: NextFunction):v
 });
 
 // get events attending / get events hosted by user 
-userRoutes.get('/getUser/events', userController.getUserEvents, (req: Request, res:Response, next:NextFunction):void => {
+userRoutes.get('/getUserEvents', userController.getUserEvents, (req: Request, res:Response, next:NextFunction):void => {
     try {
         if (!res.locals.loggedIn) res.status(401).json({message: 'You are not authorized to take this action'});
         else if (!res.locals.userEvents) res.status(400).json({message: 'User has no events!'});
@@ -82,7 +82,7 @@ userRoutes.get('/getUser', userController.getUser, (req: Request, res:Response, 
 });
 
 // edit user profile info
-userRoutes.put('/editUser/:id', userController.editUser, (req: Request, res: Response, next: NextFunction):void => {
+userRoutes.put('/editUser', userController.editUser, (req: Request, res: Response, next: NextFunction):void => {
     try {
         if (!res.locals.loggedIn) res.status(401).json({message: 'You are not authorized to take this action'});
         else if (!res.locals.editedUser) res.status(400).json({message: 'No such user exists!'});


### PR DESCRIPTION
**Issue Type**

- [] Bug
- [x] Feature

**Description**
Getting user-specific events should now differentiate between attending / attended using timestamp comparisons in postgresql.

**Previous behavior**
This was previously done by comparing the boolean field event_status, which was misunderstood. 

**Expected behavior**
Should NOT break anything

**Reviewers**
@kareemhs @blessingnt @stekim4 @larkinaj 